### PR TITLE
wip

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,76 +31,55 @@
       systems = [ "x86_64-linux" "aarch64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
       username = "kghost";
+      osConfig = system: nixpkgs.lib.nixosSystem
+        {
+          system = "aarch64-linux";
+          specialArgs = {
+            inherit self;
+            inherit (self.packages.aarch64-linux) armTrustedFirmwareMT7986;
+            inherit username;
+            inherit bpir3;
+            kernelPackages = bpir3.packages.aarch64-linux.linuxPackages_bpir3_minimal;
+            inherit inputs;
+          };
+          modules = [
+            ./nixos/hardware-configuration.nix
+            ./nixos/configuration.nix
+            "${bpir3}/lib/sd-image-mt7986.nix"
+            home-manager.nixosModules.home-manager
+            disko.nixosModules.disko
+            {
+              home-manager = {
+                useUserPackages = true;
+                useGlobalPkgs = true;
+                users.${username} = ./nixos/home.nix;
+                extraSpecialArgs = { inherit username; };
+              };
+            }
+            # flake registry
+            {
+              nix.registry.nixpkgs.flake = nixpkgs;
+            }
+            { nixpkgs.crossSystem.system = "aarch64-linux"; nixpkgs.system = system; }
+          ];
+        };
     in
     {
-      formatter = forAllSystems (system:
-        nixpkgs.legacyPackages.${system}.nixpkgs-fmt
-      );
+      # packages =
+      #   let
+      #     pkgs = import nixpkgs {
+      #       system = "aarch64-linux";
+      #       crossSystem = "aarch64-linux";
+      #       buildPlatform.system = "x86_64-linux";
+      #       hostPlatform.system = "aarch64-linux";
+      #     };
+      #   in
+      #   pkgs;
 
-      packages = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-        in
-        bpir3.packages.${system} // pkgs
-      );
-
-      nixosModules = import ./modules;
-
-      nixosConfigurations =
-        let
-          createSystem = modules: kernelPackages: nixpkgs.lib.nixosSystem {
-            system = "aarch64-linux";
-            specialArgs = {
-              inherit self;
-              inherit (self.packages.aarch64-linux) armTrustedFirmwareMT7986;
-              inherit username;
-              inherit kernelPackages;
-              inherit bpir3;
-              inherit inputs;
-            };
-            modules = [
-              home-manager.nixosModules.home-manager
-              disko.nixosModules.disko
-              {
-                home-manager = {
-                  useUserPackages = true;
-                  useGlobalPkgs = true;
-                  users.${username} = ./nixos/home.nix;
-                  extraSpecialArgs = { inherit username; };
-                };
-              }
-              # flake registry
-              {
-                nix.registry.nixpkgs.flake = nixpkgs;
-              }
-            ] ++ modules;
-          };
-        in
-        {
-          surfer =
-            let
-              modules = [
-                ./nixos/hardware-configuration.nix
-                ./nixos/configuration.nix
-                ./nixos/hostapd.nix
-                ./nixos/sops.nix
-                sops-nix.nixosModules.sops
-                "${bpir3}/lib/sd-image-mt7986.nix"
-              ];
-            in
-            createSystem modules bpir3.packages.aarch64-linux.linuxPackages_bpir3;
-          # By default there is no swap and bpir3 doesn't have enough RAM to compile full kernel
-          # Besides that, the default image does not contain key to decrypt sops-nix secrets which is needed for the wifi to start 
-          # Without wlan interfaces the br-lan intreface is unable to come-up online which prevents logging into the device. 
-          bootstrap =
-            let
-              modules = [
-                ./nixos/hardware-configuration.nix
-                ./nixos/configuration.nix
-                "${bpir3}/lib/sd-image-mt7986.nix"
-              ];
-            in
-            createSystem modules bpir3.packages.aarch64-linux.linuxPackages_bpir3_minimal;
-        };
+      nixosConfigurations.surfer = osConfig "aarch64-linux";
+    } // {
+      packages.x86_64-linux.image = (osConfig "x86_64-linux").config.system.build.sdImage;
+      defaultPackage.x86_64-linux = self.packages.x86_64-linux.image;
     };
 }
+          


### PR DESCRIPTION
tldr: splitting image and system definition so that the image can be build on x86_64 platform

```sh
$ nix build .\#packages.x86_64-linux.image                                                                           
error: a 'aarch64-linux' with features {} is required to build '/nix/store/x4gxb8zlv26gy92qx09cq2kf8q5vr91a-config.nix.drv', but I am a 'x86_64-linux' with features {benchmark, big-parallel, kvm, nixos-test}
(use '--show-trace' to show detailed location information)
```